### PR TITLE
📝 Docs: Document core NATS clipboard synchronization logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Project Conventions (AGENTS.md)
+
+## Coding Conventions
+- **Docstrings (Go):** Standard Go uses `// ` for all docstrings. Despite general documentation guidelines, for this specific project and language, use standard Go docstrings above exported functions, types, and variables. Explain the *why*, side effects, the flow, and how functions fit into the larger system.
+- **Centralized Error Reporting:** All expected/unrecoverable errors should funnel through a centralized error-reporting system. However, for internal CLI tools without explicit reporting frameworks yet configured, `log.Printf` is used as a fallback. Never swallow errors silently or leave empty catch blocks.
+
+## Operational Memory & Key Concerns Mapping
+- `main.go -> main`: Entrypoint parsing CLI flags, initializing global configurations, and running the NATS subscription/publishing event loop.
+- `main.go -> setupServer`: NATS connection and topology setup logic (creates server instance, handles reconnections, error logging, and subscribes to the clipboard sync group).
+- `main.go -> setupKey`: Derives a 256-bit SHA-256 hash from the provided password to be used as the symmetric key for AES encryption.
+- `main.go -> encrypt/decrypt`: Crypto logic handling AES-GCM encryption and decryption.
+- `.github/workflows/autorelease.yml -> CI/Release`: Consolidated GitHub Actions workflow handling CI and release automation.

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Package main implements a tool that synchronizes the system clipboard across devices
+// using NATS as the messaging fabric. Updates are symmetrically encrypted (AES-GCM)
+// before broadcast, ensuring secure state synchronization between end devices.
 package main
 
 import (
@@ -28,6 +31,10 @@ var err error
 var srv *nats.Conn // Server instance
 var sub *nats.Subscription
 
+// setupServer initializes or re-establishes the connection to the configured NATS server.
+// It modifies the global 'srv' and 'sub' variables as a side effect.
+// When called, it loops until a successful connection to the NATS host is achieved,
+// and subscribes to the device group topic. This ensures resilient connectivity.
 func setupServer() {
 	if srv != nil { // Reconnect
 		srv.Close()
@@ -55,6 +62,9 @@ func setupServer() {
 	}
 }
 
+// setupKey derives a deterministic 256-bit symmetric key from the provided password
+// to be used later in AES-GCM encryption/decryption cycles.
+// Side effect: overrides the globally allocated 'passHash' byte slice.
 func setupKey(passwd string) {
 	sha := sha256.Sum256([]byte(passwd))
 	for k := range passHash {
@@ -62,6 +72,9 @@ func setupKey(passwd string) {
 	}
 }
 
+// main is the CLI entrypoint. It parses configuration flags, initializes the network
+// and cryptographic state, and starts the infinite event loop handling both incoming NATS
+// state updates and outgoing local clipboard modifications.
 func main() {
 	var passwd string
 	flag.StringVar(&group, "g", "", "What device group exchange clipboard state updates")
@@ -128,6 +141,11 @@ func main() {
 		}
 	}
 }
+
+// encrypt converts plaintext clipboard data into an AES-GCM encrypted payload,
+// prepending a randomly generated nonce to the ciphertext for proper decryption.
+// This ensures that state updates sent over the wire cannot be easily read
+// or tampered with by the NATS broker or intermediate network elements.
 func encrypt(data []byte) ([]byte, error) {
 	block, err := aes.NewCipher(passHash)
 	if err != nil {
@@ -145,6 +163,9 @@ func encrypt(data []byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
+// decrypt extracts the prepended nonce and converts an AES-GCM ciphertext payload
+// back into plaintext clipboard data, verifying message integrity and authenticity
+// using the globally derived symmetric key.
 func decrypt(data []byte) ([]byte, error) {
 	key := []byte(passHash)
 	block, err := aes.NewCipher(key)


### PR DESCRIPTION
📝 Docs: Document core NATS clipboard synchronization logic

This PR focuses on filling documentation gaps within the codebase by adding comprehensive Go docstrings (`// ...`) to `main.go` and explicitly defining the project's documentation conventions in an `AGENTS.md` file.

### Assumptions
- The primary internal operations mapped out are `setupServer`, `setupKey`, `encrypt`, and `decrypt`.
- Despite general agent instructions mentioning JSDoc formats, Go code requires standard `// ` comments for docstrings to integrate correctly with `go doc`.
- The error handling mechanisms used (e.g., `log.Printf`) are consistent with the current scale of the CLI tool and are documented as the temporary fallback for centralized reporting.

### Alternatives Not Chosen
- Adding inline/block comments (`/* ... */`) within function bodies. This was avoided in favor of essential, pre-function block docstrings that explain the "why", side-effects, and flow as per the Essentialism philosophy.
- Modifying executable code or environment configurations (`mise.toml`, `go.mod`, `go.sum`) as part of this PR. These were intentionally avoided to adhere to strict execution guardrails that forbid changing dependencies or runnable code in a docs-focused task.

### How To Pivot
If the team prefers a different style of docstrings (e.g., more verbose parameter descriptions) or wishes to document unexported package-level variables (`srv`, `sub`, etc.), the docstrings in `main.go` can be easily amended without affecting runtime logic. The `AGENTS.md` can similarly be refined.

### Next Knobs
- **Files:** Modify `main.go` and `AGENTS.md` to refine explanations.
- **Parameters:** Alter the wording of the `// ` docstrings.
- **Steps:** If `godoc` or `swag` is introduced later, the docstring format can be adapted to support automatic generation.

---
*PR created automatically by Jules for task [2868798794920599759](https://jules.google.com/task/2868798794920599759) started by @lucasew*